### PR TITLE
Update on slug

### DIFF
--- a/app.py
+++ b/app.py
@@ -148,7 +148,7 @@ def createExhibition():
         return redirect_flask(url_for('viewExhibition'))
 
     return render_template('admin/exhibition/exhibitionCreate.html', form=form, AL_artworks=AL_artworks)
-
+'''
 @app.route("/admin/exhibition/update/<exhibition_id>", methods=['GET', 'POST'])
 def updateExhibition(exhibition_id):
     exhibition = db.exhibitions.find_one({"_id": ObjectId(exhibition_id)})
@@ -172,6 +172,38 @@ def updateExhibition(exhibition_id):
                     app.config['UPLOAD']['PRESS_RELEASE'],
                     '{0}.pdf'.format(exhibtion['slug'])
             )
+        flash('You successfully updated the exhibition data')
+        return redirect_flask(url_for('viewExhibition'))
+
+    else:
+        form = forms.ExhibitionForm(data=exhibition)
+
+    return render_template('admin/exhibition/exhibitionEdit.html', form=form)
+'''
+@app.route('/admin/exhibition/update/<slug>/', methods=['GET', 'POST'])
+def updateExhibition(slug):
+    exhibition = db.exhibitions.find_one({'slug': slug})
+
+    if request.method == 'POST':
+        form = forms.ExhibitionForm()
+
+        if form.validate_on_submit():
+            formdata=form.data
+            db.exhibitions.update(
+            {
+                '_id': exhibition['_id']
+            },
+            utils.handle_form_data(exhibition, formdata, ['press_release_file']),
+            upsert=True
+            )
+
+            if request.files['press_release_file']:
+                exhibition['press_release'] = utils.handle_uploaded_file(
+                    request.files['press_release_file'],
+                    app.config['UPLOAD']['PRESS_RELEASE'],
+                    '{0}.pdf'.format(exhibtion['slug'])
+            )
+
         flash('You successfully updated the exhibition data')
         return redirect_flask(url_for('viewExhibition'))
 

--- a/app.py
+++ b/app.py
@@ -148,38 +148,7 @@ def createExhibition():
         return redirect_flask(url_for('viewExhibition'))
 
     return render_template('admin/exhibition/exhibitionCreate.html', form=form, AL_artworks=AL_artworks)
-'''
-@app.route("/admin/exhibition/update/<exhibition_id>", methods=['GET', 'POST'])
-def updateExhibition(exhibition_id):
-    exhibition = db.exhibitions.find_one({"_id": ObjectId(exhibition_id)})
 
-    if request.method == 'POST':
-        form = forms.ExhibitionForm()
-
-        if form.validate_on_submit():
-            formdata = form.data
-            db.exhibitions.update(
-            {
-                "_id": ObjectId(exhibition_id)
-            },
-            utils.handle_form_data(exhibition, formdata, ['press_release_file']),
-            upsert=True
-            )
-
-            if request.files['press_release_file']:
-                exhibition['press_release'] = utils.handle_uploaded_file(
-                    request.files['press_release_file'],
-                    app.config['UPLOAD']['PRESS_RELEASE'],
-                    '{0}.pdf'.format(exhibtion['slug'])
-            )
-        flash('You successfully updated the exhibition data')
-        return redirect_flask(url_for('viewExhibition'))
-
-    else:
-        form = forms.ExhibitionForm(data=exhibition)
-
-    return render_template('admin/exhibition/exhibitionEdit.html', form=form)
-'''
 @app.route('/admin/exhibition/update/<slug>/', methods=['GET', 'POST'])
 def updateExhibition(slug):
     exhibition = db.exhibitions.find_one({'slug': slug})
@@ -250,9 +219,9 @@ def artistCreate():
 
     return render_template('admin/artists/artistCreate.html', form=form)
 
-@app.route("/admin/artist/update/<artist_id>", methods=['GET', 'POST'])
-def updateArtist(artist_id):
-    artist = db.artist.find_one({"_id": ObjectId(artist_id)})
+@app.route("/admin/artist/update/<slug>", methods=['GET', 'POST'])
+def updateArtist(slug):
+    artist = db.artist.find_one({'slug': slug})
 
     if request.method == 'POST':
         form = forms.ArtistForm()
@@ -261,7 +230,7 @@ def updateArtist(artist_id):
             formdata = form.data
             db.artist.update(
             {
-                "_id": ObjectId(artist_id)
+                '_id': artist['_id']
             },
             utils.handle_form_data(artist, formdata, ['press_release_file']),
             upsert=True
@@ -318,9 +287,9 @@ def createTeamMember():
 
     return render_template('admin/gallery/teammembers/galleryTeamMemberCreate.html', form=form)
 
-@app.route("/admin/edit-gallery-teammembers/<teammember_id>", methods=['GET', 'POST'])
-def updateTeamMembers(teammember_id):
-    teammember = db.teammember.find_one({"_id": ObjectId(teammember_id)})
+@app.route("/admin/edit-gallery-teammembers/<slug>", methods=['GET', 'POST'])
+def updateTeamMembers(slug):
+    teammember = db.teammember.find_one({'slug': slug})
 
     if request.method == 'POST':
         form = forms.GalleryEmployees()
@@ -329,7 +298,7 @@ def updateTeamMembers(teammember_id):
             formdata = form.data
             db.teammember.update(
             {
-                "_id": ObjectId(teammember_id)
+                '_id': teammember['_id']
             },
             utils.handle_form_data(teammember, formdata),
             upsert=True
@@ -340,7 +309,7 @@ def updateTeamMembers(teammember_id):
     else:
         form = forms.GalleryEmployees(data=teammember)
 
-    return render_template('admin/gallery/teammembers/galleryTeamMemberEdit.html', form=form, teamMemberId=teammember_id)
+    return render_template('admin/gallery/teammembers/galleryTeamMemberEdit.html', form=form)
 
 @app.route("/admin/delete-gallery-teammembers/<teammember_id>", methods=['GET', 'POST'])
 def deleteTeamMembers(teammember_id):

--- a/templates/admin/artists/artists.html
+++ b/templates/admin/artists/artists.html
@@ -13,7 +13,7 @@
             <b>{{ artists.name }}</b>
           </div>
           <div class="col-xs-4 text-right">
-            <a class="btn btn-primary btn-sm" href="/admin/artist/update/{{ artists._id }}">edit</a>
+            <a class="btn btn-primary btn-sm" href="/admin/artist/update/{{ artists.slug }}">edit</a>
             <a class="btn btn-danger btn-sm" href="/admin/artist/delete/{{ artists._id }}">delete</a>
           </div>
         </li>

--- a/templates/admin/exhibition/exhibitions.html
+++ b/templates/admin/exhibition/exhibitions.html
@@ -14,7 +14,7 @@
             <br> {{ exhibitions.start }} > {{ exhibitions.end }}
           </div>
           <div class="col-xs-4 text-right">
-            <a class="btn btn-primary btn-sm" href="/admin/exhibition/update/{{ exhibitions._id }}">edit</a>
+            <a class="btn btn-primary btn-sm" href="/admin/exhibition/update/{{ exhibitions.slug }}">edit</a>
             <a class="btn btn-danger btn-sm" href="/admin/exhibition/delete/{{ exhibitions._id }}">delete</a>
           </div>
         </li>

--- a/templates/admin/gallery/teammembers/galleryTeamMember.html
+++ b/templates/admin/gallery/teammembers/galleryTeamMember.html
@@ -13,7 +13,7 @@
                 {{ name.name }} // {{ name.slug }}
               </div>
               <div class="col-xs-4 text-right">
-                  <a class="btn btn-primary btn-sm" href="/admin/edit-gallery-teammembers/{{ name._id }}">edit</a>
+                  <a class="btn btn-primary btn-sm" href="/admin/edit-gallery-teammembers/{{ name.slug }}">edit</a>
                   <a class="btn btn-danger btn-sm" href="/admin/delete-gallery-teammembers/{{ name._id }}">delete</a>
               </div>
             </li>

--- a/templates/admin/gallery/teammembers/galleryTeamMemberEdit.html
+++ b/templates/admin/gallery/teammembers/galleryTeamMemberEdit.html
@@ -5,7 +5,7 @@
 
 {% block body %}
 <div class="col-md-8">
-    <h3>Edit opening hour</h3>
+    <h3>Edit team member info</h3>
     {% include 'admin/gallery/teammembers/galleryTeamMemberForm.html' %}
 </div>
 {% endblock %}

--- a/templates/admin/gallery/teammembers/galleryTeamMemberForm.html
+++ b/templates/admin/gallery/teammembers/galleryTeamMemberForm.html
@@ -1,5 +1,5 @@
 {% from "helpers/_form.html" import render_field %}
-<form method="post" action="/admin/edit-gallery-teammembers/{{ teamMemberId }}">
+<form method="post" enctype="multipart/form-data">
     {{ form.csrf_token }}
     {{ render_field(form.name) }}
     {{ render_field(form.role) }}


### PR DESCRIPTION
This works to make the form content update method be based on a slugifyed name, just to make it easier to read, but I don't know yet if the slug itself needs to be updated along with the _id. Or if the slug should be the only value that gets updated and not the _id.

From what I can understand, manipulating the _id is crucial, if a document does not have and _id, it does not exist. My concern is about hard linking & outside linking to the website for example if the url `http://localhost:5000/exhibition/mood/`gets changed to `http://localhost:5000/exhibition/moods/`then links will end up being dead. 

I'm leaving this as a pull request, because I need @gijsdeheij 's knowledge. 
